### PR TITLE
Fix package installer deprecation warnings in Ansible 2.7

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,31 +6,28 @@
 
 - name: install the required dependencies (Debian)
   apt:
-    name: "{{ item }}"
+    name:
+    - openssl
+    - python-boto
+    - python-openssl
     state: present
-  with_items:
-  - openssl
-  - python-boto
-  - python-openssl
   when: ansible_os_family == 'Debian'
 
 - name: install the required dependencies (Red Hat) (Requires EPEL)
   yum:
-    name: "{{ item }}"
+    name:
+    - openssl
+    - python-pip
     state: present
-  with_items:
-  - openssl
-  - python-pip
   when: ansible_os_family == 'RedHat'
 
 - name: install the required dependencies (FreeBSD)
   pkgng:
-    name: "{{ item }}"
+    name:
+    - openssl
+    - py27-boto
+    - py27-openssl
     state: present
-  with_items:
-  - openssl
-  - py27-boto
-  - py27-openssl
   when: ansible_os_family == 'FreeBSD'
 
 - name: "create the {{ ler53_cert_dir }} directory"


### PR DESCRIPTION
Using a loop on a package module via squash_actions
The use of squash_actions to invoke a package module, such as “yum”, to only invoke the module once is deprecated, and will be removed in Ansible 2.11.

https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_2.7.html#using-a-loop-on-a-package-module-via-squash-actions