### PR TITLE
Use ansible built-in file lookup instead of cat

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -159,23 +159,14 @@
   register: ler53_intermediate_download_task
   when: ler53_intermediate_download
 
-- name: get content of the certificate
-  command: "cat {{ ler53_cert_dir }}/{{ ler53_cert_file_name }}"
-  register: ler53_certificate_content
-  changed_when: false
-  when: ler53_intermediate_download
-
-- name: get content of the intermediate CA
-  command: "cat {{ ler53_cert_dir }}/{{ ler53_intermediate_file_name }}"
-  register: ler53_intermediate_content
-  changed_when: false
-  when: ler53_intermediate_download
-
 - name: create a file with the certificate and intermediate CA concatenated
   copy:
-    content: "{{ ler53_certificate_content['stdout'] + '\n' + ler53_intermediate_content['stdout'] + '\n' }}"
+    content: "{{ lookup('file', cert_path) + '\n' + lookup('file', intermediate_path) + '\n' }}"
     dest: "{{ ler53_cert_dir }}/{{ ler53_cert_and_intermediate_file_name }}"
     owner: "{{ ler53_cert_files_owner }}"
     group: "{{ ler53_cert_files_group }}"
     mode: "{{ ler53_cert_files_mode }}"
+  vars:
+    cert_path: "{{ ler53_cert_dir }}/{{ ler53_cert_file_name }}"
+    intermediate_path: "{{ ler53_cert_dir }}/{{ ler53_intermediate_file_name }}"
   when: ler53_intermediate_download


### PR DESCRIPTION
When constructing the full certificate chain, use Ansible's `lookup` plugin to read file contents instead of shelling out to `cat` with a command.