### PR TITLE
Update tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,6 +68,10 @@
   import_tasks: virtualenv.yml
   when: ansible_os_family == 'RedHat'
 
+- name: "set hostname to {{ ler53_cert_common_name }}"
+  hostname:
+    name: "{{ ler53_cert_common_name }}"
+
 - name: generate the private key
   openssl_privatekey:
     path: "{{ ler53_cert_dir }}/{{ ler53_key_file_name }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,8 @@
     update_cache: yes
     cache_valid_time: 3600
   when: ansible_os_family == 'Debian'
+  tags:
+  - install
 
 - name: install the required dependencies (Debian) python3
   apt:
@@ -13,6 +15,8 @@
     - python3-openssl
     state: present
   when: ansible_os_family == 'Debian' and ansible_python_version is version('3', '>=')
+  tags:
+  - install
 
 - name: install the required dependencies (Debian) python2
   apt:
@@ -22,6 +26,8 @@
     - python-openssl
     state: present
   when: ansible_os_family == 'Debian' and ansible_python_version is version('3', '<')
+  tags:
+  - install
 
 - name: install the required dependencies (Red Hat) (Requires EPEL)
   yum:
@@ -30,6 +36,8 @@
     - python-pip
     state: present
   when: ansible_os_family == 'RedHat'
+  tags:
+  - install
 
 - name: install the required dependencies (FreeBSD)
   pkgng:
@@ -39,6 +47,8 @@
     - py27-openssl
     state: present
   when: ansible_os_family == 'FreeBSD'
+  tags:
+  - install
 
 - name: "create the {{ ler53_cert_dir }} directory"
   file:
@@ -54,7 +64,8 @@
     owner: root
     mode: 0700
 
-- include: virtualenv.yml
+- name: "importing virtualenv tasks"
+  import_tasks: virtualenv.yml
   when: ansible_os_family == 'RedHat'
 
 - name: generate the private key
@@ -64,11 +75,15 @@
     owner: "{{ ler53_cert_files_owner }}"
     group: "{{ ler53_cert_files_group }}"
     mode: "{{ ler53_cert_files_mode }}"
+  tags:
+  - openssl
 
 - name: check consistency of private key
   openssl_privatekey_info:
     path: "{{ ler53_cert_dir }}/{{ ler53_key_file_name }}"
   register: result_privatekey
+  tags:
+  - openssl
 
 - name: generate the CSR
   openssl_csr:
@@ -82,11 +97,15 @@
     group: "{{ ler53_cert_files_group }}"
     mode: "{{ ler53_cert_files_mode }}"
   register: generate_csr
+  tags:
+  - openssl
 
 - name: check consistency of the CSR key
   openssl_csr_info:
     path: "{{ ler53_cert_dir }}/{{ ler53_csr_file_name }}"
   register: result_csr
+  tags:
+  - openssl
 
 - name: generate the Let's Encrypt account key
   openssl_privatekey:
@@ -95,11 +114,15 @@
     owner: "{{ ler53_cert_files_owner }}"
     group: "{{ ler53_cert_files_group }}"
     mode: "{{ ler53_cert_files_mode }}"
+  tags:
+  - openssl
 
 - name: check consistency of the account key
   openssl_privatekey_info:
     path: "{{ ler53_account_key_dir }}/{{ ler53_account_key_file_name }}"
   register: result_accountkey
+  tags:
+  - openssl
 
 - name: delete existing certificate
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,10 +68,6 @@
   import_tasks: virtualenv.yml
   when: ansible_os_family == 'RedHat'
 
-- name: "set hostname to {{ ler53_cert_common_name }}"
-  hostname:
-    name: "{{ ler53_cert_common_name }}"
-
 - name: generate the private key
   openssl_privatekey:
     path: "{{ ler53_cert_dir }}/{{ ler53_key_file_name }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: update apt cache
   apt:
     update_cache: yes
+    cache_valid_time: 3600
   when: ansible_os_family == 'Debian'
 
 - name: install the required dependencies (Debian) python3
@@ -49,9 +50,9 @@
 - name: "create the {{ ler53_account_key_dir }} directory"
   file:
     path: "{{ ler53_account_key_dir }}"
+    state: directory
     owner: root
     mode: 0700
-    state: directory
 
 - include: virtualenv.yml
   when: ansible_os_family == 'RedHat'
@@ -60,10 +61,6 @@
   openssl_privatekey:
     path: "{{ ler53_cert_dir }}/{{ ler53_key_file_name }}"
     size: "{{ ler53_key_size }}"
-
-- name: set the private key file permissions
-  file:
-    path: "{{ ler53_cert_dir }}/{{ ler53_key_file_name }}"
     owner: "{{ ler53_cert_files_owner }}"
     group: "{{ ler53_cert_files_group }}"
     mode: "{{ ler53_cert_files_mode }}"
@@ -76,25 +73,18 @@
     key_usage: "{{ ler53_cert_key_usages }}"
     subject_alt_name: "DNS:{{ ler53_cert_common_name }}{{ ',DNS:' + ',DNS:'.join(ler53_cert_sans) if ler53_cert_sans else '' }}"
     extended_key_usage: "{{ ler53_cert_extended_key_usages | default(omit) }}"
-  register: generate_csr
-
-- name: set the CSR file permissions
-  file:
-    path: "{{ ler53_cert_dir }}/{{ ler53_csr_file_name }}"
     owner: "{{ ler53_cert_files_owner }}"
     group: "{{ ler53_cert_files_group }}"
     mode: "{{ ler53_cert_files_mode }}"
+  register: generate_csr
 
 - name: generate the Let's Encrypt account key
   openssl_privatekey:
     path: "{{ ler53_account_key_dir }}/{{ ler53_account_key_file_name }}"
     size: "{{ ler53_account_key_size }}"
-
-- name: set the Let's Encrypt account key file permissions
-  file:
-    path: "{{ ler53_account_key_dir }}/{{ ler53_account_key_file_name }}"
-    owner: root
-    mode: 0600
+    owner: "{{ ler53_cert_files_owner }}"
+    group: "{{ ler53_cert_files_group }}"
+    mode: "{{ ler53_cert_files_mode }}"
 
 - name: delete existing certificate
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,6 +65,11 @@
     group: "{{ ler53_cert_files_group }}"
     mode: "{{ ler53_cert_files_mode }}"
 
+- name: check consistency of private key
+  openssl_privatekey_info:
+    path: "{{ ler53_cert_dir }}/{{ ler53_key_file_name }}"
+  register: result_privatekey
+
 - name: generate the CSR
   openssl_csr:
     path: "{{ ler53_cert_dir }}/{{ ler53_csr_file_name }}"
@@ -78,6 +83,11 @@
     mode: "{{ ler53_cert_files_mode }}"
   register: generate_csr
 
+- name: check consistency of the CSR key
+  openssl_csr_info:
+    path: "{{ ler53_cert_dir }}/{{ ler53_csr_file_name }}"
+  register: result_csr
+
 - name: generate the Let's Encrypt account key
   openssl_privatekey:
     path: "{{ ler53_account_key_dir }}/{{ ler53_account_key_file_name }}"
@@ -85,6 +95,11 @@
     owner: "{{ ler53_cert_files_owner }}"
     group: "{{ ler53_cert_files_group }}"
     mode: "{{ ler53_cert_files_mode }}"
+
+- name: check consistency of the account key
+  openssl_privatekey_info:
+    path: "{{ ler53_account_key_dir }}/{{ ler53_account_key_file_name }}"
+  register: result_accountkey
 
 - name: delete existing certificate
   file:
@@ -185,3 +200,11 @@
     group: "{{ ler53_cert_files_group }}"
     mode: "{{ ler53_cert_files_mode }}"
   when: ler53_intermediate_download | bool
+
+- name: verify certificates
+  assert:
+    that:
+      - result_privatekey.key_is_consistent
+      - result_accountkey.key_is_consistent
+      - result_csr.signature_valid
+    msg: "all certificates are valid!"

--- a/tasks/virtualenv.yml
+++ b/tasks/virtualenv.yml
@@ -8,6 +8,8 @@
     - openssl-devel
     - libffi-devel
     state: present
+  tags:
+  - install
 
 - name: install pyOpenSSL and boto in a virtualenv
   pip:
@@ -27,6 +29,8 @@
   - name: enum34
   - name: ipaddress
   - name: cffi
+  tags:
+  - install
 
 - name: use the created virtualenv
   set_fact:


### PR DESCRIPTION
1. The permissions can be set in the same task of the creation of the keys.
2. Tests to verify the integrity of the certs, in case they are not corrupted of invalid.
3. Adding tags makes easier to skip unwanted tasks to be re-run.