### PR TITLE
Avoid clash witht the outer loop variable

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: handle services
   service:
-    name: "{{ item.name }}"
-    state: "{{ item.state }}"
+    name: "{{ ler53_item.name }}"
+    state: "{{ ler53_item.state }}"
   with_items: "{{ ler53_service_handlers }}"
+  loop_control:
+    loop_var: ler53_item

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -149,15 +149,17 @@
   route53:
     command: create
     zone: "{{ ler53_route_53_domain }}"
-    record: "{{ item.value['dns-01']['record'] }}"
+    record: "{{ ler53_item.value['dns-01']['record'] }}"
     type: TXT
     ttl: 5
-    value: "\"{{ item.value['dns-01']['resource_value'] }}\""
+    value: "\"{{ ler53_item.value['dns-01']['resource_value'] }}\""
     aws_access_key: "{{ ler53_aws_access_key }}"
     aws_secret_key: "{{ ler53_aws_secret_key }}"
     overwrite: yes
     wait: yes
   with_dict: "{{ lets_encrypt_challenge['challenge_data'] | default({}) }}"
+  loop_control:
+    loop_var: ler53_item
 
 - name: validate the Let's Encrypt challenge
   acme_certificate:
@@ -180,13 +182,15 @@
   route53:
     command: delete
     zone: "{{ ler53_route_53_domain }}"
-    record: "{{ item.value['dns-01']['record'] }}"
+    record: "{{ ler53_item.value['dns-01']['record'] }}"
     type: TXT
     ttl: 5
-    value: "\"{{ item.value['dns-01']['resource_value'] }}\""
+    value: "\"{{ ler53_item.value['dns-01']['resource_value'] }}\""
     aws_access_key: "{{ ler53_aws_access_key }}"
     aws_secret_key: "{{ ler53_aws_secret_key }}"
   with_dict: "{{ lets_encrypt_challenge['challenge_data'] | default({}) }}"
+  loop_control:
+    loop_var: ler53_item
 
 - name: set the cert file permissions
   file:

--- a/tasks/virtualenv.yml
+++ b/tasks/virtualenv.yml
@@ -13,9 +13,9 @@
 
 - name: install pyOpenSSL and boto in a virtualenv
   pip:
-    name: "{{ item.name }}"
-    state: "{{ item.state | default(omit) }}"
-    version: "{{ item.version | default(omit) }}"
+    name: "{{ ler53_item.name }}"
+    state: "{{ ler53_item.state | default(omit) }}"
+    version: "{{ ler53_item.version | default(omit) }}"
     virtualenv: "{{ ler53_account_key_dir }}/ansible-lets-encrypt-virtualenv"
     # This is required for libselinux-python
     virtualenv_site_packages: yes
@@ -29,6 +29,8 @@
   - name: enum34
   - name: ipaddress
   - name: cffi
+  loop_control:
+    loop_var: ler53_item
   tags:
   - install
 


### PR DESCRIPTION
When calling the lets-encrypt-route-53 role in a loop, the following warning
was issued by Ansible:

[WARNING]: The loop variable 'item' is already in use. You should set
the `loop_var` value in the `loop_control` option for the task to something
else to avoid variable collisions and unexpected behavior.