### PR TITLE
Adding support for MacOS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ This is an Ansible role that automates the generation of Let's Encrypt signed ce
 Amazon's Route 53 (AWS).
 
 Please note that as part of this role, `openssl`, [boto](https://github.com/boto/boto), and
-[pyOpenSSL](https://github.com/pyca/pyopenssl) will be installed. If you are using CentOS/Red Hat, the role will
+[pyOpenSSL](https://github.com/pyca/pyopenssl) will be installed. If you are using CentOS/Red Hat/ Mac OS, the role will
 install `pip` (requires [EPEL](https://fedoraproject.org/wiki/EPEL)) and then install `boto` and `pyOpenSSL` in a
 Python virtualenv instead because the packaged version of `pyOpenSSL` is not recent enough.
 
-If you are not using this role on Debian/Ubuntu, CentOS/Red Hat,
+If you are not using this role on Debian/Ubuntu, CentOS/Red Hat, Mac OS,
 or FreeBSD, `openssl`, `boto`, and `pyOpenSSL` must be installed manually before using this role.
 
 ## Requirements
@@ -60,7 +60,7 @@ without waiting for it to expire. This defaults to `false`.
 * **ler53_cert_extended_key_usages** - Additional restrictions (e.g. client authentication, server authentication) on the allowed purposes for which the public key may be used.
 * **ler53_service_handlers** - A list of dictionaries describing service handlers to run when a certificate is updated in the format of `{'name': 'httpd', 'state': 'restarted'}`.
 * **ler53_acme_directory** - The ACME directory to use. This defaults to `https://acme-v02.api.letsencrypt.org/directory`. This can be useful to override if you'd like to test this role against the stage Let's Encrypt instance.
-  
+
 ## Example Playbook
 
 ```yaml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,6 +50,17 @@
   tags:
   - install
 
+- name: install the required dependencies (MacOS)
+  homebrew:
+    name:
+    - openssl@1.1
+    - python3
+    state: present
+  become: no
+  when: ansible_os_family == 'Darwin'
+  tags:
+  - install
+
 - name: "create the {{ ler53_cert_dir }} directory"
   file:
     path: "{{ ler53_cert_dir }}"
@@ -66,7 +77,7 @@
 
 - name: "importing virtualenv tasks"
   import_tasks: virtualenv.yml
-  when: ansible_os_family == 'RedHat'
+  when: ansible_os_family in ['RedHat', 'Darwin']
 
 - name: generate the private key
   openssl_privatekey:

--- a/tasks/virtualenv.yml
+++ b/tasks/virtualenv.yml
@@ -1,5 +1,5 @@
 ---
-- name: install the virtualenv requirements
+- name: install the virtualenv requirements (Red Hat)
   yum:
     name:
     - python-virtualenv
@@ -8,10 +8,19 @@
     - openssl-devel
     - libffi-devel
     state: present
+  when: ansible_os_family == 'RedHat'
   tags:
   - install
 
-- name: install pyOpenSSL and boto in a virtualenv
+- name: install virtualenv (MacOS)
+  pip:
+    name: virtualenv
+    state: present
+  when: ansible_os_family == 'Darwin'
+  tags:
+  - install
+
+- name: install pyOpenSSL and boto in a virtualenv (Red Hat/ MacOS)
   pip:
     name: "{{ ler53_item.name }}"
     state: "{{ ler53_item.state | default(omit) }}"


### PR DESCRIPTION
## Changes
- Support for Darwin
  - Install packages on MacOS using homebrew and drop privileges when doing so.
  - Install pip packages using pip + virtualenv for openssl and route53 module.

## Tested on:
- Mac OS Catalina
```
❯ sw_vers
ProductName:	Mac OS X
ProductVersion:	10.15.4
BuildVersion:	19E287

❯ brew --version
Homebrew 2.2.13
Homebrew/homebrew-core (git revision 85cb3; last commit 2020-04-23)
Homebrew/homebrew-cask (git revision 43dad; last commit 2020-04-24)
```
- Sample playbook:
```
- hosts: localhost
  gather_facts: yes
  become: yes
  vars_files:
    - "{{ playbook_dir }}/vars/ler53_vars.yml"

  tasks:
    - name: Obtain SSL cert for VCSA
      include_role:
        name: "{{ playbook_dir | basedir }}/roles/ansible-role-lets-encrypt-route-53"
```
Run:
```
PLAY RECAP *****************************************************************************************************************************************************************************************************
localhost                  : ok=22   changed=4    unreachable=0    failed=0    skipped=10   rescued=0    ignored=0
```