### PR TITLE
Revert ansible interpreter

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -248,3 +248,8 @@
       - result_accountkey.key_is_consistent
       - result_csr.signature_valid
     msg: "The private keys and CSR are valid"
+
+- name: "Revert python interpreter"
+  set_fact:
+    ansible_python_interpreter: "{{ python_interpreter }}"
+  when: python_interpreter is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -252,4 +252,4 @@
 - name: "Revert python interpreter"
   set_fact:
     ansible_python_interpreter: "{{ ansible_facts['discovered_interpreter_python'] }}"
-  when: revert_python_interpreter
+  when: revert_python_interpreter is defined and revert_python_interpreter == true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -251,5 +251,5 @@
 
 - name: "Revert python interpreter"
   set_fact:
-    ansible_python_interpreter: "{{ python_interpreter }}"
-  when: python_interpreter is defined
+    ansible_python_interpreter: "{{ ansible_facts['discovered_interpreter_python'] }}"
+  when: revert_python_interpreter

--- a/tasks/virtualenv.yml
+++ b/tasks/virtualenv.yml
@@ -42,6 +42,12 @@
   tags:
   - install
 
+- name: Record python interpreter
+  set_fact:
+    python_interpreter: "{{ ansible_python_interpreter }}"
+  tags:
+    - install
+
 - name: use the created virtualenv
   set_fact:
     ansible_python_interpreter: "{{ ler53_account_key_dir }}/ansible-lets-encrypt-virtualenv/bin/python"

--- a/tasks/virtualenv.yml
+++ b/tasks/virtualenv.yml
@@ -42,9 +42,9 @@
   tags:
   - install
 
-- name: Record python interpreter
+- name: Set python interpreter revert flag
   set_fact:
-    python_interpreter: "{{ ansible_python_interpreter }}"
+    revert_python_interpreter: true
   tags:
     - install
 


### PR DESCRIPTION
This is probably a bit of an edge case, but I noticed an issue when using this role.

To replicate the issue, you would have to have a playbook that delegates a task to localhost once the plays in this role have completed. I was getting a permission denied on the path to the python in the virtualenv, presumably because it doesn't exist on localhost.

The fix is to flag that the interpreter has been changed and revert to the 'discovered' python interpreter at the end of the plays in the role.
