### PR TITLE
LetsEncrypt seems to be issuing certificates from the R3 intermediate instead of X3…

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -212,7 +212,7 @@
 
 - name: download the Let's Encrypt intermediate CA
   get_url:
-    url: https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem
+    url: https://letsencrypt.org/certs/lets-encrypt-r3-cross-signed.pem
     dest: "{{ ler53_cert_dir }}/{{ ler53_intermediate_file_name }}"
     owner: "{{ ler53_cert_files_owner }}"
     group: "{{ ler53_cert_files_group }}"


### PR DESCRIPTION
Fixes issues noted in https://github.com/mprahl/ansible-role-lets-encrypt-route-53/issues/33.