### PR TITLE
Add capabilities to change the intermediate CA to download

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,3 +23,4 @@ ler53_account_key_file_name: lets_encrypt_account.key
 ler53_new_cert_when_csr_changes: false
 ler53_service_handlers: []
 ler53_acme_directory: https://acme-v02.api.letsencrypt.org/directory
+ler53_intermediate_download_url: https://letsencrypt.org/certs/lets-encrypt-r3-cross-signed.pem

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -212,7 +212,7 @@
 
 - name: download the Let's Encrypt intermediate CA
   get_url:
-    url: https://letsencrypt.org/certs/lets-encrypt-r3-cross-signed.pem
+    url: "{{ ler53_intermediate_download_url }}"
     dest: "{{ ler53_cert_dir }}/{{ ler53_intermediate_file_name }}"
     owner: "{{ ler53_cert_files_owner }}"
     group: "{{ ler53_cert_files_group }}"


### PR DESCRIPTION
### Changes

  * Provide the capability to change the intermediate CA, useful when you change the `ler53_acme_directory`
  * By default, change nothing (get the intermediate certificate at `https://letsencrypt.org/certs/lets-encrypt-r3-cross-signed.pem`)
