### PR TITLE
Add ler53_route_53_zone_id paramater

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,11 @@ Ansible 2.7+ is required for this role. If you are using an older version of Ans
   domain the SSL certificate is being generated for.
 * **ler53_aws_secret_key** - the secret key to an AWS user that is allowed to add records to the
   domain the SSL certificate is being generated for.
-* **ler53_route_53_domain** - the Route 53 (AWS) domain/zone the SSL certificate is being generated
-  for.
+* **ler53_route_53_domain** - the Route 53 (AWS) domain the SSL certificate is being generated
+  for. This is a required parameter, if parameter `ler53_route_53_zone_id` is not supplied.
+* **ler53_route_53_zone_id** - the Route 53 (AWS) zone_id the SSL certificate is being generated
+  for. This is a required parameter, if parameter `ler53_route_53_domain` is not supplied. Use
+  this parameter if you don't have the AWS rights to perform route53:ListHostedZones.
 
 #### Optional Variables
 * **ler53_cert_common_name** - the common name for the SSL certificate being generated. This

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -159,7 +159,8 @@
 - name: create the DNS records for the challenge
   route53:
     command: create
-    zone: "{{ ler53_route_53_domain }}"
+    zone: "{{ ler53_route_53_domain | default(omit) }}"
+    hosted_zone_id: "{{ ler53_route_53_zone_id | default(omit) }}"
     record: "{{ ler53_item.value['dns-01']['record'] }}"
     type: TXT
     ttl: 5
@@ -192,7 +193,8 @@
 - name: delete the DNS records for the challenge
   route53:
     command: delete
-    zone: "{{ ler53_route_53_domain }}"
+    zone: "{{ ler53_route_53_domain | default(omit) }}"
+    hosted_zone_id: "{{ ler53_route_53_zone_id | default(omit) }}"
     record: "{{ ler53_item.value['dns-01']['record'] }}"
     type: TXT
     ttl: 5


### PR DESCRIPTION
Currently, the lets-encrypt-route-53 role requires permissions to
perfom route53:ListHostedZones on AWS. This doens't work for restricted
accounts. Add the parameter ler53_route_53_zone_id which can be used
instead of the ler53_route_53_domain and which doesn't require the
aforementioned AWS permission.