### PR TITLE
Use python 3 boto and openssl packages on FreeBSD instead of removed python 2.7 equivalents

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,8 +43,8 @@
   pkgng:
     name:
     - openssl
-    - py27-boto
-    - py27-openssl
+    - py37-boto
+    - py37-openssl
     state: present
   when: ansible_os_family == 'FreeBSD'
   tags:


### PR DESCRIPTION
Fixes #40 

`py27-openssl-19.1.0` is still available at this time, but this PR future proofs against its potential removal also.