### PR TITLE
Fixed a bug in tasks/main, last step "verify the private keys and CSR"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -102,6 +102,7 @@
 - name: check consistency of private key
   openssl_privatekey_info:
     path: "{{ ler53_cert_dir }}/{{ ler53_key_file_name }}"
+    check_consistency: yes
   register: result_privatekey
   tags:
   - openssl
@@ -141,6 +142,7 @@
 - name: check consistency of the account key
   openssl_privatekey_info:
     path: "{{ ler53_account_key_dir }}/{{ ler53_account_key_file_name }}"
+    check_consistency: yes
   register: result_accountkey
   tags:
   - openssl


### PR DESCRIPTION
openssl_privatekey_info now requires parameter check_consistency: yes to be explicitly specified in order to get the key_is_consistent variable in the result. Without doing this, openssl_privatekey never sets the "key_is_consistent" variable and the last step of tasks/main,yml fails.

This is on ansible version [core 2.11.7]
