### PR TITLE
Allow AWS SDK to determine the AWS credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@ Ansible 2.7+ is required for this role. If you are using an older version of Ans
 * **ler53_cert_changed** - this is set to `True` when the certificate is created or renewed.
 
 #### Required Variables
-* **ler53_aws_access_key** - the access key to an AWS user that is allowed to add records to the
-  domain the SSL certificate is being generated for.
-* **ler53_aws_secret_key** - the secret key to an AWS user that is allowed to add records to the
-  domain the SSL certificate is being generated for.
 * **ler53_route_53_domain** - the Route 53 (AWS) domain the SSL certificate is being generated
   for. This is a required parameter, if parameter `ler53_route_53_zone_id` is not supplied.
 * **ler53_route_53_zone_id** - the Route 53 (AWS) zone_id the SSL certificate is being generated
@@ -92,6 +88,14 @@ Ansible 2.7+ is required for this role. If you are using an older version of Ans
 * **ler53_acme_directory** - The ACME directory to use. This defaults to
   `https://acme-v02.api.letsencrypt.org/directory`. This can be useful to override if you'd like to
   test this role against the stage Let's Encrypt instance.
+* **ler53_aws_access_key** - the access key to an AWS user that is allowed to add records to the
+  domain the SSL certificate is being generated for. If not specified, the AWS SDK will
+  [determine](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html)
+  the access key.
+* **ler53_aws_secret_key** - the secret key to an AWS user that is allowed to add records to the
+  domain the SSL certificate is being generated for. If not specified, the AWS SDK will
+  [determine](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html)
+  the secret key.
 
 ## Example Playbook
 
@@ -103,8 +107,6 @@ Ansible 2.7+ is required for this role. If you are using an older version of Ans
   vars:
   - ler53_cert_common_name: host.example.com
   - ler53_route_53_domain: example.com
-  - ler53_aws_access_key: SomeAccessKey
-  - ler53_aws_secret_key: SomeSecretKey
 
   roles:
   - mprahl.lets-encrypt-route-53

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -177,8 +177,8 @@
     type: TXT
     ttl: 5
     value: "\"{{ ler53_item.value['dns-01']['resource_value'] }}\""
-    aws_access_key: "{{ ler53_aws_access_key }}"
-    aws_secret_key: "{{ ler53_aws_secret_key }}"
+    aws_access_key: "{{ ler53_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ ler53_aws_secret_key | default(omit) }}"
     overwrite: yes
     wait: yes
   with_dict: "{{ lets_encrypt_challenge['challenge_data'] | default({}) }}"
@@ -212,8 +212,8 @@
     type: TXT
     ttl: 5
     value: "\"{{ ler53_item.value['dns-01']['resource_value'] }}\""
-    aws_access_key: "{{ ler53_aws_access_key }}"
-    aws_secret_key: "{{ ler53_aws_secret_key }}"
+    aws_access_key: "{{ ler53_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ ler53_aws_secret_key | default(omit) }}"
   with_dict: "{{ lets_encrypt_challenge['challenge_data'] | default({}) }}"
   loop_control:
     loop_var: ler53_item


### PR DESCRIPTION
If the user doesn't specify AWS credentials, let AWS SDK determine the credentials from configuration files and environment variables.