### PR TITLE
Fix virtualenv task for python3 Closes mprahl/ansible-role-lets-encrypt-route-53#56

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,17 +60,6 @@
   tags:
   - install
 
-- name: install the required dependencies (MacOS)
-  homebrew:
-    name:
-    - openssl@1.1
-    - python3
-    state: present
-  become: no
-  when: ansible_os_family == 'Darwin'
-  tags:
-  - install
-
 - name: "create the {{ ler53_cert_dir }} directory"
   file:
     path: "{{ ler53_cert_dir }}"

--- a/tasks/virtualenv.yml
+++ b/tasks/virtualenv.yml
@@ -25,14 +25,6 @@
   tags:
   - install
 
-- name: install virtualenv (MacOS)
-  pip:
-    name: virtualenv
-    state: present
-  when: ansible_os_family == 'Darwin'
-  tags:
-  - install
-
 - name: install pyOpenSSL and boto in a virtualenv (Red Hat/ MacOS)
   pip:
     name: "{{ ler53_item.name }}"
@@ -41,12 +33,13 @@
     virtualenv: "{{ ler53_account_key_dir }}/ansible-lets-encrypt-virtualenv"
     # This is required for libselinux-python
     virtualenv_site_packages: yes
+    virtualenv_command: "{{ ansible_python_interpreter }} -m venv"
   with_items:
-  # Update setuptools
-  - name: setuptools>44.0.0,<45.0.0
-    state: present
+ # Update setuptools
+  #- name: setuptools>44.0.0,<45.0.0
+  #  state: present
   - name: pyOpenSSL
-  - name: boto
+  - name: boto3
   - name: enum34
   - name: ipaddress
   - name: cffi
@@ -58,5 +51,6 @@
 - name: use the created virtualenv
   set_fact:
     ansible_python_interpreter: "{{ ler53_account_key_dir }}/ansible-lets-encrypt-virtualenv/bin/python"
+  when: not ansible_check_mode
   tags:
   - install


### PR DESCRIPTION
Install packages to venv using python3 semantics. I have removed the homebrew task as I don't believe it provides value. It is easy for user to install openssl dependency and it is now not necessary to use homebrew. Please be patient, this is my first pull request and I am only dependent on ansible docs.